### PR TITLE
Use slack-notifier instead of pretty-slack-notify

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -15,8 +15,8 @@ services:
 
 default: &default
     after-steps:
-        - wantedly/pretty-slack-notify:
-            webhook_url: $SLACK_WEBHOOK_URL
+        - slack-notifier:
+            url: $SLACK_WEBHOOK_URL
             username: wercker_build
 
 # This is the build pipeline. Pipelines are the core of wercker


### PR DESCRIPTION
pretty-slack-notify doesn't work on ruby 2.5.0 (maybe)

https://app.wercker.com/sue445/cure-mastodon-bots/runs/build-rspec/5a42d86bf59174000149dab9?step=5a42d88796da83000190075d


```
Bundle complete! 25 Gemfile dependencies, 75 gems now installed.
Bundled gems are installed into `/pipeline/cache/bundle-install`
bundler: failed to load command: /pipeline/pretty-slack-notify-1a5b7855-eb8f-4d5f-903c-3e3588ac6ca5/run.rb (/pipeline/pretty-slack-notify-1a5b7855-eb8f-4d5f-903c-3e3588ac6ca5/run.rb)
LoadError: cannot load such file -- slack-notifier
  /pipeline/pretty-slack-notify-1a5b7855-eb8f-4d5f-903c-3e3588ac6ca5/run.rb:3:in `require'
  /pipeline/pretty-slack-notify-1a5b7855-eb8f-4d5f-903c-3e3588ac6ca5/run.rb:3:in `<top (required)>'
```