### PR TITLE
Fix warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
 ruby "2.5.3"
 
 # NOTE: https://github.com/tootsuite/mastodon-api/pull/11 is not released

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/tootsuite/mastodon-api.git
+  remote: https://github.com/tootsuite/mastodon-api
   revision: 39f4b0354f3c15075d16e9a810d695824a230b0b
   ref: 39f4b0
   branch: master


### PR DESCRIPTION
```
The git source `git://github.com/tootsuite/mastodon-api.git` uses the `git` protocol, which transmits data without encryption.
Disable this warning with `bundle config git.allow_insecure true`, or switch to the `https` protocol to keep your data secure.
```